### PR TITLE
Feature 35 server stats command

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,9 @@ Discord bot for Eddie Jaoude's Discord server
    - [Where can I find my User/Server/Message ID?](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-)
 - ID of your discord server, to get your server ID follow these steps:
    - First make sure you have **Developer Mode** enabled on your Discord by visiting your Discord settings and going to Appearance
+   ![user settings button](https://user-images.githubusercontent.com/18630253/83634306-3458c180-a59a-11ea-8a96-15e9751b9d08.png)
+   ![developer mode toggle button](https://user-images.githubusercontent.com/18630253/83634441-7a158a00-a59a-11ea-919c-2d7384d724f7.png)
+
    - Right click on the server icon on the left hand sidebar then click on "Copy ID"
 - [optional] GCP account to deploy to (using GitHub Actions)
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Discord bot for Eddie Jaoude's Discord server
 - general channel ID of your discord server, read the instructions on one of these links to get yours:
    - [Get the channel ID of the Discord text channel](https://github.com/Chikachi/DiscordIntegration/wiki/How-to-get-a-token-and-channel-ID-for-Discord#get-the-channel-id-of-the-discord-text-channel)
    - [Where can I find my User/Server/Message ID?](https://support.discord.com/hc/en-us/articles/206346498-Where-can-I-find-my-User-Server-Message-ID-)
+- ID of your discord server, to get your server ID follow these steps:
+   - First make sure you have **Developer Mode** enabled on your Discord by visiting your Discord settings and going to Appearance
+   - Right click on the server icon on the left hand sidebar then click on "Copy ID"
 - [optional] GCP account to deploy to (using GitHub Actions)
 
 ## Quickstart
@@ -17,9 +20,10 @@ Discord bot for Eddie Jaoude's Discord server
 2. Install dependencies by running the command `npm install`
 
 ## Run the project locally on Mac and Linux using below command 
-1. `DISCORD_TOKEN=<GET YOUR DISCORD TOKEN> GENERAL_CHANNEL_ID=<GET YOUR GENERAL CHANNEL ID> npm run start:local`
+1. `DISCORD_TOKEN=<GET YOUR DISCORD TOKEN> GENERAL_CHANNEL_ID=<GET YOUR GENERAL CHANNEL ID> DISCORD_SERVER_ID=<YOUR SERVER_ID> npm run start:local`
 
 ## Run on Windows using below commands
 1. `set DISCORD_TOKEN=<GET YOUR DISCORD TOKEN>`
 2. `set GENERAL_CHANNEL_ID=<GET YOUR GENERAL CHANNEL ID>`
+2. `set DISCORD_SERVER_ID=<YOUR SERVER_ID>`
 3. `npm run start:local`

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,6 +1,7 @@
-import { Message, MessageEmbed, Client } from "discord.js";
+import { Message, MessageEmbed } from "discord.js";
+import { StatsService } from "./stats/statsService";
 
-export const commands = (message: Message) => {
+export const commands = async (message: Message, statsService: StatsService) => {
 	const prefix = '!';
 	if (!message.content.startsWith(prefix) || message.author.bot) {
 		return;
@@ -41,10 +42,12 @@ export const commands = (message: Message) => {
 			break;
 
 		case 'stats':
-			const memberCount = getServerMemberCount(message.client);
+			const memberCount = await statsService.getServerMemberCount();
+			const totalMessages = await statsService.getServerTotalMessages();
 			embed
 				.setTitle('Server stats')
 				.addField('total users', memberCount)
+				.addField('total messages', totalMessages)
 			break;
 	
 		default:
@@ -56,22 +59,3 @@ export const commands = (message: Message) => {
 console.log('HELP');
     message.channel.send(embed);
 };
-
-/**
- * @returns the number of members in the server configured by the environment variables or null if there was an error
- */
-export function getServerMemberCount(client: Client) {
-    const guildKey = process.env.DISCORD_SERVER_ID
-    if (!guildKey) {
-        console.error(`ERROR: Couldn't get member count! Missing env. variable DISCORD_SERVER_ID. Please configure that value.`)
-        return 0
-    }
-
-    const guild = client.guilds.cache.get(guildKey)
-    if (!guild) {
-        console.error(`ERROR: Couldn't get member count! The guild with the configured DISCORD_SERVER_ID env. variable doesn't exist`)
-        return 0
-    }
-
-    return guild.memberCount
-}

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,4 +1,4 @@
-import { Message, MessageEmbed } from "discord.js";
+import { Message, MessageEmbed, Client } from "discord.js";
 
 export const commands = (message: Message) => {
 	const prefix = '!';
@@ -40,6 +40,13 @@ export const commands = (message: Message) => {
 				.addField('Full details availabe on GitHub repo', 'https://github.com/eddiejaoude/EddieBot/blob/master/CODE_OF_CONDUCT.md', true)
 			break;
 
+		case 'stats':
+			const memberCount = getServerMemberCount(message.client);
+			embed
+				.setTitle('Server stats')
+				.addField('total users', memberCount)
+			break;
+	
 		default:
 			embed
 				.setTitle('ERROR: ooops...command not found')
@@ -49,3 +56,22 @@ export const commands = (message: Message) => {
 console.log('HELP');
     message.channel.send(embed);
 };
+
+/**
+ * @returns the number of members in the server configured by the environment variables or null if there was an error
+ */
+export function getServerMemberCount(client: Client) {
+    const guildKey = process.env.DISCORD_SERVER_ID
+    if (!guildKey) {
+        console.error(`ERROR: Couldn't get member count! Missing env. variable DISCORD_SERVER_ID. Please configure that value.`)
+        return 0
+    }
+
+    const guild = client.guilds.cache.get(guildKey)
+    if (!guild) {
+        console.error(`ERROR: Couldn't get member count! The guild with the configured DISCORD_SERVER_ID env. variable doesn't exist`)
+        return 0
+    }
+
+    return guild.memberCount
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,9 +4,12 @@ import { guildMemberAdd } from './guildMemberAdd';
 import { messageReactionAdd } from './messageReactionAdd';
 import { chatty } from './chatty';
 import { notifyGeneralChannel } from './notifyGeneralChannel';
+import { DiscordStatsService } from './stats/discordStatsService';
 
 // initial client with params
 const client: Client = new Client({ partials: ['MESSAGE', 'CHANNEL', 'REACTION'] });
+
+const discordStatsService = new DiscordStatsService(client)
 
 // client is ready
 client.once('ready', () => console.log('Ready LOCAL!'));
@@ -14,7 +17,7 @@ client.once('ready', () => console.log('Ready LOCAL!'));
 // bot actions
 client.on('channelCreate', notifyGeneralChannel);
 client.on('guildMemberAdd', (member) => guildMemberAdd(member));
-client.on('message', message => commands(message));
+client.on('message', message => commands(message, discordStatsService));
 client.on('message', message => chatty(message));
 client.on('messageReactionAdd', async (reaction) => messageReactionAdd(reaction))
 

--- a/src/stats/discordStatsService.ts
+++ b/src/stats/discordStatsService.ts
@@ -12,7 +12,7 @@ export class DiscordStatsService implements StatsService {
     }
 
     /**
-     * @returns the number of members in the server configured by the environment variables or null if there was an error
+     * @returns the number of members in the server configured by the environment variables or 0 if there was an error
      */
     async getServerMemberCount(): Promise<number> {
         const guildKey = process.env.DISCORD_SERVER_ID;

--- a/src/stats/discordStatsService.ts
+++ b/src/stats/discordStatsService.ts
@@ -17,13 +17,13 @@ export class DiscordStatsService implements StatsService {
     async getServerMemberCount(): Promise<number> {
         const guildKey = process.env.DISCORD_SERVER_ID;
         if (!guildKey) {
-            console.error(`ERROR: Couldn't get member count! Missing env. variable DISCORD_SERVER_ID. Please configure that value.`);
+            console.error("ERROR: Couldn't get member count! Missing env. variable DISCORD_SERVER_ID. Please configure that value.");
             return 0;
         }
     
         const guild = this.client.guilds.cache.get(guildKey);
         if (!guild) {
-            console.error(`ERROR: Couldn't get member count! The guild with the configured DISCORD_SERVER_ID env. variable doesn't exist`);
+            console.error("ERROR: Couldn't get member count! The guild with the configured DISCORD_SERVER_ID env. variable doesn't exist");
             return 0;
         }
     

--- a/src/stats/discordStatsService.ts
+++ b/src/stats/discordStatsService.ts
@@ -1,0 +1,42 @@
+import { StatsService } from "./statsService";
+import { Client } from "discord.js";
+
+/**
+ * Uses the Discord API to implement the StatsService interface.
+ */
+export class DiscordStatsService implements StatsService {
+    private client: Client;
+
+    constructor(client: Client) {
+        this.client = client;
+    }
+
+    /**
+     * @returns the number of members in the server configured by the environment variables or null if there was an error
+     */
+    async getServerMemberCount(): Promise<number> {
+        const guildKey = process.env.DISCORD_SERVER_ID;
+        if (!guildKey) {
+            console.error(`ERROR: Couldn't get member count! Missing env. variable DISCORD_SERVER_ID. Please configure that value.`);
+            return 0;
+        }
+    
+        const guild = this.client.guilds.cache.get(guildKey);
+        if (!guild) {
+            console.error(`ERROR: Couldn't get member count! The guild with the configured DISCORD_SERVER_ID env. variable doesn't exist`);
+            return 0;
+        }
+    
+        return guild.memberCount;
+    }
+
+    async getServerTotalMessages(): Promise<number> {
+        // TODO: implement this
+        return 0;
+    }
+
+    async getServerTotalReactions(): Promise<number> {
+        // TODO: implement this
+        return 0;
+    }
+}

--- a/src/stats/statsService.ts
+++ b/src/stats/statsService.ts
@@ -1,0 +1,5 @@
+export interface StatsService {
+    getServerMemberCount(): Promise<number>;
+    getServerTotalMessages(): Promise<number>;
+    getServerTotalReactions(): Promise<number>;
+}


### PR DESCRIPTION
This PR only implements one of the tasks for this feature for now. The idea is to keep developing the **stats feature** in this PR. The function `getServerMemberCount()` uses the Discord API to get the number of total users.

Like it was discussed on the issue #35, this data can come from a DB later on. Which means the current implementation can be improved to support this, without changing the `commands.ts` file. By moving the function `getServerMemberCount` (and possible others like getTotalMessages, etc) to an interface, the `commands` module isn't coupled to an implementation, and we can decide to fetch from the DB or Discord API. Overall this would improve the encapsulation of the code.

Let me know your thoughts 🙂.

---
_Edit: 30/05/2020_
### Summary
- A new command was added: `!stats`
- Added the folder `/stats` to hold the files related to this feature: `StatsService` and `DiscordStatsService`. For now, we have these 3 operations:
```ts
export interface StatsService {
    getServerMemberCount(): Promise<number>;
    getServerTotalMessages(): Promise<number>;
    getServerTotalReactions(): Promise<number>;
}
```
- The `commands` module uses an instance of this service, and so the way this data is fetched is **abstracted** by the interface. The commands function should only be responsible for building the message for the user.

@eddiejaoude I'm not sure how to implement the DB part and how we should save/read this data. Do we have firebase set up yet or were you thinking of using another service?