### PR TITLE
feat(commandSplitting): #38 Move commands to their own file

### DIFF
--- a/src/commandHandlers/codeOfConduct.ts
+++ b/src/commandHandlers/codeOfConduct.ts
@@ -1,0 +1,27 @@
+import { MessageEmbed } from 'discord.js'
+
+export const command = (embed: MessageEmbed) => {
+  return embed
+    .setTitle('Code of Conduct (CoC) - Contributor Covenant Code of Conduct')
+    .setDescription(
+      `We as members, contributors, and leaders pledge to make participation in our
+  community a harassment-free experience for everyone, regardless of age, body
+  size, visible or invisible disability, ethnicity, sex characteristics, gender
+  identity and expression, level of experience, education, socio-economic status,
+  nationality, personal appearance, race, religion, or sexual identity
+  and orientation.
+  We pledge to act and interact in ways that contribute to an open, welcoming,
+  diverse, inclusive, and healthy community.
+  Our Standards`
+    )
+    .addField('TLDR', 'Be nice :)', true)
+    .addField(
+      'Full details available on GitHub repo',
+      'https://github.com/eddiejaoude/EddieBot/blob/master/CODE_OF_CONDUCT.md',
+      true
+    )
+}
+
+export const description = 'Code Of Conduct'
+
+export const triggers = ['coc', 'codeofconduct']

--- a/src/commandHandlers/fallback.ts
+++ b/src/commandHandlers/fallback.ts
@@ -1,0 +1,9 @@
+import { MessageEmbed } from 'discord.js'
+import config from '../config'
+const { COMMAND_PREFIX } = config
+
+export const fallback = (embed: MessageEmbed) => {
+  return embed
+    .setTitle('ERROR: ooops...command not found')
+    .setDescription(`Try using the ${COMMAND_PREFIX}help command.`)
+}

--- a/src/commandHandlers/help.ts
+++ b/src/commandHandlers/help.ts
@@ -1,0 +1,20 @@
+import { MessageEmbed } from 'discord.js'
+import commandList from './index'
+import config from '../config'
+const { COMMAND_PREFIX } = config
+
+export const command = (embed: MessageEmbed) => {
+  embed.setTitle('Help commands').setDescription('Lists the command available')
+
+  commandList.forEach(({ triggers, description }) => {
+    const mainTrigger = `${COMMAND_PREFIX}${triggers[0]}`
+
+    embed.addField(mainTrigger, description, true)
+  })
+
+  return embed
+}
+
+export const description = 'Lists available commands'
+
+export const triggers = ['help']

--- a/src/commandHandlers/index.ts
+++ b/src/commandHandlers/index.ts
@@ -1,0 +1,5 @@
+import * as codeOfConduct from './codeOfConduct'
+import * as help from './help'
+
+export default [codeOfConduct, help]
+export { fallback } from './fallback'

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -1,51 +1,21 @@
-import { Message, MessageEmbed } from "discord.js";
+import { Message } from 'discord.js'
+import commandList, { fallback } from './commandHandlers'
+import config from './config'
+const { COMMAND_PREFIX, defaultEmbed } = config
 
 export const commands = (message: Message) => {
-	const prefix = '!';
-	if (!message.content.startsWith(prefix) || message.author.bot) {
-		return;
-	}
+  if (!message.content.startsWith(COMMAND_PREFIX) || message.author.bot) {
+    return
+  }
 
-	const args = message.content.slice(prefix.length).split(/ +/);
-	const command = args.shift()!.toLowerCase();
+  const args = message.content.slice(COMMAND_PREFIX.length).split(/ +/)
+  const command = args.shift()!.toLowerCase()
 
-	const embed = new MessageEmbed()
-		.setColor('#0099ff')
-		.setTimestamp()
-		.setFooter('Our bot is Open Source, you can find it here https://github.com/eddiejaoude/EddieBot');
+  const embed = defaultEmbed()
 
-	switch (command) {
-		case 'help':
-            		embed
-			.setTitle('Help commands')
-			.setDescription('Lists the command available')
-			.addField('!help', 'Lists available commands', true)
-				.addField('!coc', 'Code of Conduct', true)
-			break;
+  const matching = commandList.find(({ triggers }) =>
+    triggers.find(trigger => trigger === command)
+  ) || { command: fallback }
 
-		case 'codeofconduct':
-		case 'coc':
-			embed
-				.setTitle('Code of Conduct (CoC) - Contributor Covenant Code of Conduct')
-				.setDescription(`We as members, contributors, and leaders pledge to make participation in our
-				community a harassment-free experience for everyone, regardless of age, body
-				size, visible or invisible disability, ethnicity, sex characteristics, gender
-				identity and expression, level of experience, education, socio-economic status,
-				nationality, personal appearance, race, religion, or sexual identity
-				and orientation.
-				We pledge to act and interact in ways that contribute to an open, welcoming,
-				diverse, inclusive, and healthy community.
-				Our Standards`)
-				.addField('TLDR', 'Be nice :)', true)
-				.addField('Full details availabe on GitHub repo', 'https://github.com/eddiejaoude/EddieBot/blob/master/CODE_OF_CONDUCT.md', true)
-			break;
-
-		default:
-			embed
-				.setTitle('ERROR: ooops...command not found')
-				.setDescription('Try using the !help command.')
-        		break;
-    }
-console.log('HELP');
-    message.channel.send(embed);
-};
+  message.channel.send(matching.command(embed))
+}

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,0 +1,13 @@
+import { MessageEmbed } from 'discord.js'
+
+export default {
+  COMMAND_PREFIX: '!',
+  defaultEmbed: () => {
+    return new MessageEmbed()
+      .setColor('#0099ff')
+      .setTimestamp()
+      .setFooter(
+        'Our bot is Open Source, you can find it here https://github.com/eddiejaoude/EddieBot'
+      )
+  }
+}


### PR DESCRIPTION
Added in a commandHandlers folder where you can place commands in their own files.

Also added in a configuration file for setting the default command prefix and embed code.

This allows for adding in commands easier and not having one giant commands file filled up and hard to read.